### PR TITLE
Allow SerializerBuilder.Reset() to be Used in Multi-Threaded Test Frameworks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -132,7 +132,7 @@ var settings = new JsonSerializerSettings
     DefaultValueHandling = DefaultValueHandling.Ignore
 };
 ```
-<sup>[snippet source](/src/ObjectApproval/Helpers/SerializerBuilder.cs#L145-L154)</sup>
+<sup>[snippet source](/src/ObjectApproval/Helpers/SerializerBuilder.cs#L137-L146)</sup>
 <!-- endsnippet -->
 
 

--- a/src/MSTests/Data/ParallelTests.Eight.ForScenario.Parallel.Ignore.Eight.approved.txt
+++ b/src/MSTests/Data/ParallelTests.Eight.ForScenario.Parallel.Ignore.Eight.approved.txt
@@ -1,0 +1,9 @@
+﻿{
+  One: 1,
+  Two: 2,
+  Three: 3,
+  Four: 4,
+  Five: 5,
+  Six: 6,
+  Seven: 7
+}

--- a/src/MSTests/Data/ParallelTests.Five.ForScenario.Parallel.Ignore.Five.approved.txt
+++ b/src/MSTests/Data/ParallelTests.Five.ForScenario.Parallel.Ignore.Five.approved.txt
@@ -1,0 +1,9 @@
+﻿{
+  One: 1,
+  Two: 2,
+  Three: 3,
+  Four: 4,
+  Six: 6,
+  Seven: 7,
+  Eight: 8
+}

--- a/src/MSTests/Data/ParallelTests.Four.ForScenario.Parallel.Ignore.Four.approved.txt
+++ b/src/MSTests/Data/ParallelTests.Four.ForScenario.Parallel.Ignore.Four.approved.txt
@@ -1,0 +1,9 @@
+﻿{
+  One: 1,
+  Two: 2,
+  Three: 3,
+  Five: 5,
+  Six: 6,
+  Seven: 7,
+  Eight: 8
+}

--- a/src/MSTests/Data/ParallelTests.One.ForScenario.Parallel.Ignore.One.approved.txt
+++ b/src/MSTests/Data/ParallelTests.One.ForScenario.Parallel.Ignore.One.approved.txt
@@ -1,0 +1,9 @@
+﻿{
+  Two: 2,
+  Three: 3,
+  Four: 4,
+  Five: 5,
+  Six: 6,
+  Seven: 7,
+  Eight: 8
+}

--- a/src/MSTests/Data/ParallelTests.Seven.ForScenario.Parallel.Ignore.Seven.approved.txt
+++ b/src/MSTests/Data/ParallelTests.Seven.ForScenario.Parallel.Ignore.Seven.approved.txt
@@ -1,0 +1,9 @@
+﻿{
+  One: 1,
+  Two: 2,
+  Three: 3,
+  Four: 4,
+  Five: 5,
+  Six: 6,
+  Eight: 8
+}

--- a/src/MSTests/Data/ParallelTests.Six.ForScenario.Parallel.Ignore.Six.approved.txt
+++ b/src/MSTests/Data/ParallelTests.Six.ForScenario.Parallel.Ignore.Six.approved.txt
@@ -1,0 +1,9 @@
+﻿{
+  One: 1,
+  Two: 2,
+  Three: 3,
+  Four: 4,
+  Five: 5,
+  Seven: 7,
+  Eight: 8
+}

--- a/src/MSTests/Data/ParallelTests.Three.ForScenario.Parallel.Ignore.Three.approved.txt
+++ b/src/MSTests/Data/ParallelTests.Three.ForScenario.Parallel.Ignore.Three.approved.txt
@@ -1,0 +1,9 @@
+﻿{
+  One: 1,
+  Two: 2,
+  Four: 4,
+  Five: 5,
+  Six: 6,
+  Seven: 7,
+  Eight: 8
+}

--- a/src/MSTests/Data/ParallelTests.Two.ForScenario.Parallel.Ignore.Two.approved.txt
+++ b/src/MSTests/Data/ParallelTests.Two.ForScenario.Parallel.Ignore.Two.approved.txt
@@ -1,0 +1,9 @@
+﻿{
+  One: 1,
+  Three: 3,
+  Four: 4,
+  Five: 5,
+  Six: 6,
+  Seven: 7,
+  Eight: 8
+}

--- a/src/MSTests/MSTests.csproj
+++ b/src/MSTests/MSTests.csproj
@@ -1,23 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\ObjectApproval\ObjectApproval.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Data\" />
-  </ItemGroup>
-
 </Project>

--- a/src/MSTests/MSTests.csproj
+++ b/src/MSTests/MSTests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ObjectApproval\ObjectApproval.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Data\" />
+  </ItemGroup>
+
+</Project>

--- a/src/MSTests/ParallelTests.cs
+++ b/src/MSTests/ParallelTests.cs
@@ -1,0 +1,89 @@
+﻿using ObjectApproval;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ApprovalTests.Reporters;
+using ApprovalTests.Namers;
+
+
+[TestClass]
+[UseReporter(typeof(DiffReporter))]
+[UseApprovalSubdirectory("Data")]
+public class ParallelTests
+{
+    [TestInitialize]
+    public void Setup()
+    {
+        SerializerBuilder.Reset();
+    }
+
+    private class TestObject
+    {
+        public int One { get; set; } = 1;
+        public int Two { get; set; } = 2;
+        public int Three { get; set; } = 3;
+        public int Four { get; set; } = 4;
+        public int Five { get; set; } = 5;
+        public int Six { get; set; } = 6;
+        public int Seven { get; set; } = 7;
+        public int Eight { get; set; } = 8;
+    }
+
+    [TestMethod]
+    public void One()
+    {
+        RunTest("One");
+    }
+
+    [TestMethod]
+    public void Two()
+    {
+        RunTest("Two");
+    }
+
+    [TestMethod]
+    public void Three()
+    {
+        RunTest("Three");
+    }
+
+    [TestMethod]
+    public void Four()
+    {
+        RunTest("Four");
+    }
+
+    [TestMethod]
+    public void Five()
+    {
+        RunTest("Five");
+    }
+
+    [TestMethod]
+    public void Six()
+    {
+        RunTest("Six");
+    }
+
+    [TestMethod]
+    public void Seven()
+    {
+        RunTest("Seven");
+    }
+
+    [TestMethod]
+    public void Eight()
+    {
+        RunTest("Eight");
+    }
+
+    public void RunTest(string memberToIgnore)
+    {
+        SerializerBuilder.IgnoreMember(typeof(TestObject), memberToIgnore);
+
+        var testObject = new TestObject();
+
+        using (ApprovalResults.ForScenario("Parallel.Ignore." + memberToIgnore))
+        {
+            ObjectApprover.VerifyWithJson(testObject);
+        }
+    }
+}

--- a/src/MSTests/Properties/Assembly.cs
+++ b/src/MSTests/Properties/Assembly.cs
@@ -1,0 +1,5 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ObjectApproval;
+
+[assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]
+[assembly: ObjectApprovalBehavior(SerializerThreadingMode = SerializerThreadingMode.MultiThreaded)]

--- a/src/ObjectApproval.sln
+++ b/src/ObjectApproval.sln
@@ -13,6 +13,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MSTests", "MSTests\MSTests.csproj", "{427278E3-B4C5-4D0D-943B-95DB0201D7D2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{76FE87D9-EF6B-4D31-99F2-7099C719AE99}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{76FE87D9-EF6B-4D31-99F2-7099C719AE99}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{76FE87D9-EF6B-4D31-99F2-7099C719AE99}.Release|Any CPU.Build.0 = Release|Any CPU
+		{427278E3-B4C5-4D0D-943B-95DB0201D7D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{427278E3-B4C5-4D0D-943B-95DB0201D7D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{427278E3-B4C5-4D0D-943B-95DB0201D7D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{427278E3-B4C5-4D0D-943B-95DB0201D7D2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ObjectApproval/Helpers/ObjectApprovalBehaviorAttribute.cs
+++ b/src/ObjectApproval/Helpers/ObjectApprovalBehaviorAttribute.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace ObjectApproval
+{
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
+    public class ObjectApprovalBehaviorAttribute : Attribute
+    {
+        public ObjectApprovalBehaviorAttribute() { }
+        public SerializerThreadingMode SerializerThreadingMode { get; set; } = SerializerThreadingMode.SingleThreaded;
+    }
+}

--- a/src/ObjectApproval/Helpers/Serialization/SerializerSettingsStore.cs
+++ b/src/ObjectApproval/Helpers/Serialization/SerializerSettingsStore.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using Newtonsoft.Json;
 using System.Threading;
-using System.Reflection;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
+using ApprovalUtilities.CallStack;
 
 namespace ObjectApproval
 {
@@ -11,13 +11,8 @@ namespace ObjectApproval
     {
         public static ISerializerSettingsStore Create()
         {
-            var mode = SerializerThreadingMode.SingleThreaded;
-
-            var attributes = Assembly.GetExecutingAssembly().GetCustomAttributes(typeof(ObjectApprovalBehaviorAttribute), false);
-            if (attributes.Length != 0 && attributes[0] is ObjectApprovalBehaviorAttribute objectApprovalAttribute)
-            {
-                mode = objectApprovalAttribute.SerializerThreadingMode;
-            }
+            var behaviorAttribute = new Caller().GetFirstFrameForAttribute<ObjectApprovalBehaviorAttribute>();
+            var mode = behaviorAttribute == null ? SerializerThreadingMode.SingleThreaded : behaviorAttribute.SerializerThreadingMode;
 
             switch(mode)
             {

--- a/src/ObjectApproval/Helpers/Serialization/SerializerSettingsStore.cs
+++ b/src/ObjectApproval/Helpers/Serialization/SerializerSettingsStore.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using Newtonsoft.Json;
+using System.Threading;
+using System.Reflection;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+
+namespace ObjectApproval
+{
+    internal static class SerializerSettingsStorageFactory
+    {
+        public static ISerializerSettingsStore Create()
+        {
+            var mode = SerializerThreadingMode.SingleThreaded;
+
+            var attributes = Assembly.GetExecutingAssembly().GetCustomAttributes(typeof(ObjectApprovalBehaviorAttribute), false);
+            if (attributes.Length != 0 && attributes[0] is ObjectApprovalBehaviorAttribute objectApprovalAttribute)
+            {
+                mode = objectApprovalAttribute.SerializerThreadingMode;
+            }
+
+            switch(mode)
+            {
+                case SerializerThreadingMode.SingleThreaded:
+                    return new SingleThreadedSerializerSettingsStore();
+                case SerializerThreadingMode.MultiThreaded:
+                    return new MultiThreadedSerializerSettingsStore();
+            }
+
+            throw new ArgumentException($"Received an unsupported threading mode: {mode.ToString()}");
+        }
+    }
+
+    internal interface ISerializerSettingsStore
+    {
+        void Reset();
+
+        ConcurrentDictionary<Type, ConcurrentBag<string>> IgnoreMembersByName { get; }
+        ConcurrentDictionary<Type, ConcurrentBag<Func<object, bool>>> IgnoredInstances { get; }
+        List<Type> IgnoreMembersWithType { get; }
+        List<Func<Exception, bool>> IgnoreMembersThatThrow { get; }
+
+        bool IgnoreEmptyCollections { get; set; }
+        bool IgnoreFalse { get; set; }
+        bool ScrubGuids { get; set; }
+        bool ScrubDateTimes { get; set; }
+
+        Action<JsonSerializerSettings> ExtraSettings { get; set; }
+    }
+
+    internal class SingleThreadedSerializerSettingsStore : ISerializerSettingsStore
+    {
+        public SingleThreadedSerializerSettingsStore()
+        {
+            Reset();
+        }
+
+        public void Reset()
+        {
+            IgnoreMembersByName.Clear();
+            IgnoredInstances.Clear();
+            IgnoreMembersWithType.Clear();
+            IgnoreMembersThatThrow.Clear();
+
+            IgnoreEmptyCollections = true;
+            IgnoreFalse = true;
+            ScrubGuids = true;
+            ScrubDateTimes = true;
+
+            ExtraSettings = settings => { };
+        }
+
+        public ConcurrentDictionary<Type, ConcurrentBag<string>> IgnoreMembersByName { get; } = new ConcurrentDictionary<Type, ConcurrentBag<string>>();
+        public ConcurrentDictionary<Type, ConcurrentBag<Func<object, bool>>> IgnoredInstances { get; } = new ConcurrentDictionary<Type, ConcurrentBag<Func<object, bool>>>();
+        public List<Type> IgnoreMembersWithType { get; } = new List<Type>();
+        public List<Func<Exception, bool>> IgnoreMembersThatThrow { get; } = new List<Func<Exception, bool>>();
+
+        public bool IgnoreEmptyCollections { get; set; }
+        public bool IgnoreFalse { get; set; }
+        public bool ScrubGuids { get; set; }
+        public bool ScrubDateTimes { get; set; }
+        public Action<JsonSerializerSettings> ExtraSettings { get; set; }
+    }
+
+    internal class MultiThreadedSerializerSettingsStore : ISerializerSettingsStore
+    {
+        private ThreadLocal<SingleThreadedSerializerSettingsStore> _innerStore = new ThreadLocal<SingleThreadedSerializerSettingsStore>(() => new SingleThreadedSerializerSettingsStore());
+
+        public void Reset()
+        {
+            _innerStore.Value.Reset();
+        }
+
+        public ConcurrentDictionary<Type, ConcurrentBag<string>> IgnoreMembersByName => _innerStore.Value.IgnoreMembersByName;
+        public ConcurrentDictionary<Type, ConcurrentBag<Func<object, bool>>> IgnoredInstances => _innerStore.Value.IgnoredInstances;
+        public List<Type> IgnoreMembersWithType => _innerStore.Value.IgnoreMembersWithType;
+        public List<Func<Exception, bool>> IgnoreMembersThatThrow => _innerStore.Value.IgnoreMembersThatThrow;
+
+        public bool IgnoreEmptyCollections { get => _innerStore.Value.IgnoreEmptyCollections; set => _innerStore.Value.IgnoreEmptyCollections = value; }
+        public bool IgnoreFalse { get => _innerStore.Value.IgnoreFalse; set => _innerStore.Value.IgnoreFalse = value; }
+        public bool ScrubGuids { get => _innerStore.Value.ScrubGuids; set => _innerStore.Value.ScrubGuids = value; }
+        public bool ScrubDateTimes { get => _innerStore.Value.ScrubDateTimes; set => _innerStore.Value.ScrubDateTimes = value; }
+        public Action<JsonSerializerSettings> ExtraSettings { get => _innerStore.Value.ExtraSettings; set => _innerStore.Value.ExtraSettings = value; }
+    }
+}

--- a/src/ObjectApproval/Helpers/Serialization/SerializerThreadingMode.cs
+++ b/src/ObjectApproval/Helpers/Serialization/SerializerThreadingMode.cs
@@ -1,0 +1,8 @@
+﻿namespace ObjectApproval
+{
+    public enum SerializerThreadingMode
+    {
+        SingleThreaded,
+        MultiThreaded
+    }
+}

--- a/src/ObjectApproval/Helpers/Serialization/SerializerThreadingMode.cs
+++ b/src/ObjectApproval/Helpers/Serialization/SerializerThreadingMode.cs
@@ -1,5 +1,16 @@
 ﻿namespace ObjectApproval
 {
+    /// <summary>
+    /// <para>
+    /// Can be set on an assembly level with <see cref="ObjectApprovalBehaviorAttribute"/>
+    /// </para>
+    /// <para>
+    /// SingleThreaded mode means that all threds will share changes to <see cref="SerializerBuilder"/> 
+    /// </para>
+    /// <para>
+    /// MultiThreaded mode means that each thread will have its own set of changes to <see cref="SerializerBuilder"/>
+    /// </para>
+    /// </summary>
     public enum SerializerThreadingMode
     {
         SingleThreaded,

--- a/src/Tests/TestConfig.cs
+++ b/src/Tests/TestConfig.cs
@@ -1,5 +1,7 @@
 ﻿using ApprovalTests.Reporters;
 using Xunit;
+using ObjectApproval;
 
 [assembly: UseReporter(typeof(AllFailingTestsClipboardReporter), typeof(DiffReporter))]
-[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true)]
+//[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true)]
+[assembly: ObjectApprovalBehavior(SerializerThreadingMode = SerializerThreadingMode.MultiThreaded)]

--- a/src/Tests/TestConfig.cs
+++ b/src/Tests/TestConfig.cs
@@ -1,7 +1,5 @@
 ﻿using ApprovalTests.Reporters;
-using Xunit;
 using ObjectApproval;
 
 [assembly: UseReporter(typeof(AllFailingTestsClipboardReporter), typeof(DiffReporter))]
-//[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true)]
 [assembly: ObjectApprovalBehavior(SerializerThreadingMode = SerializerThreadingMode.MultiThreaded)]


### PR DESCRIPTION
Hello Simon,

I was attempting to upgrade an integration test project to use parallel execution and realized that my usage of the Reset() functionality that I added prevented that from happening.

Looking through the commits around the time it was introduced, I realize you also ran into this issue >> https://github.com/SimonCropp/ObjectApproval/commit/b8acb0bd14603d6ca511570b467b8dad27242bc5

Perhaps the most appropriate way of fixing it would be to remove the "Reset()" functionality and convert to solely using data scrubbers and/or scoped serializers.

Regardless, these changes fix the problem while preserving the existing functionality & interface of the SerializerBuilder.

If you'd rather not have these changes I am okay with that, there are other paths to fix the problems I am running into. 

## The Fix
The core of the fix is moving all storage of settings into some implementation of the `ISerializerSettingsStore` interface. There are two implementations of this interface, `SingleThreadedSerializerSettingsStore` and `MultiThreadedSerializerSettingsStore`.

All the multithreaded serializer settings store does is store the actual settings in a `private ThreadLocal<SingleThreadedSerializerSettingsStore> _innerStore` and all implementations of the `ISerializerSettingsStore` interface just refer to `_innerStore.Value`.

In the static constructor for SerializerBuilder, we just read an assembly level `ObjectApprovalBehavior` attribute to know whether or not we need to use the single or multi threaded implementation.

As far as I could tell, the test projects (XUnit & MSTestV2) were using proper threads when running tests in parallel so I believe this fix will work.

## Unit Test Updates

For the XUnit tests I just reenabled test parallelization. I also created an MSTest project to verify. I'm not certain it is sufficient, but I couldn't get the tests to pass when I set the serializer threading mode to single threaded so I believe they are testing the right thing.
